### PR TITLE
Add optional input notify_on_changed_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ If the optional input `notify_on_changed_status` is set to a non-empty string, t
 
 `yes|no` depending on if the message should be sent
 
+### last_message
+
+status of the last completed workflow
+
 ## How to use
 
 In this case, the action will take into account the result of `job1` and `job2` for builds only for the `main` branch. 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,15 @@ A GitHub action to decide if a status message should be pushed to slack for this
 
 ## How it makes the decision
 
+If the optional input `notify_on_changed_status` is not set or set to the empty string, then:
+
 1. If the current build failed, then it will recommend sending the message
 2. If the current build succeeded, and the previous one failed, then it will recommend sending the message
 3. If the current build succeeded, and the previous one succeeded, then it will recommend NOT sending the message
+
+If the optional input `notify_on_changed_status` is set to a non-empty string, then:
+
+1. If the status of the current and the last build differ, then it will recommend sending the message
 
 ## Inputs
 
@@ -22,6 +28,10 @@ A GitHub action to decide if a status message should be pushed to slack for this
 ### github_token
 
 **required** A github token (secrets.GITHUB_TOKEN will suffice)
+
+### notify_on_changed_status
+
+**optional** Defaults to `''`. See section [How it makes the decision](#how-it-makes-the-decision).
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,11 @@ outputs:
     description: "`yes|no` depending on if the message should be sent"
     value: ${{ steps.determine-notification.outputs.should_send_message }}
   last_status:
-    description: "status of the last completed workflow"
+    description: "status of the previously completed workflow (or null)"
     value: ${{ steps.determine-notification.outputs.last_status }}
+  current_status:
+    description: "status of the current workflow"
+    value: ${{ steps.determine-notification.outputs.current_status }}
 runs:
   using: "composite"
   steps:
@@ -52,6 +55,8 @@ runs:
         else
             current_status=success
         fi
+        echo "status of the current build: $current_status"
+        echo "::set-output name=current_status::$current_status"
         if [[ "${{ inputs.notify_on_changed_status }}" ]]; then
             if [[ $current_status == $last_status ]]; then
               echo "::set-output name=should_send_message::no"

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
         last_status=$(curl --silent --header 'authorization: Bearer ${{ inputs.github_token }}' \
                       --header 'content-type: application/json' \
                       "https://api.github.com/repos/${{ github.repository }}/actions/workflows/$workflow_id/runs?per_page=1&status=completed&branch=${{ inputs.branch }}" | jq -r .workflow_runs[0].conclusion)
-        if [[  $last_status != success && $last_status != failure ]]; then
+        if [[  $last_status != success && $last_status != failure && $last_status != null ]]; then
             echo "Invalid \$last_status: $last_status"
             exit 1
         else

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
   github_token:
     description: 'A github token (secrets.GITHUB_TOKEN will suffice)'
     required: true
+  notify_on_changed_status:
+    description: 'Set to a non-empty string to return yes if and only if the status changed'
+    required: false
+    default: ''
 outputs:
   should_send_message:
     description: "`yes|no` depending on if the message should be sent"
@@ -32,13 +36,30 @@ runs:
         last_status=$(curl --silent --header 'authorization: Bearer ${{ inputs.github_token }}' \
                       --header 'content-type: application/json' \
                       "https://api.github.com/repos/${{ github.repository }}/actions/workflows/$workflow_id/runs?per_page=1&status=completed&branch=${{ inputs.branch }}" | jq -r .workflow_runs[0].conclusion)
-        echo "status of the previous build: $last_status"
-        needs_context="${{ inputs.needs_context }}"
-
-        if [[ $(echo $needs_context | grep "result: failure") ]]; then
-          echo "::set-output name=should_send_message::yes"
-        elif [[ $last_status == failure ]]; then
-          echo "::set-output name=should_send_message::yes"
+        if [[  $last_status != success && $last_status != failure ]]; then
+            echo "Invalid \$last_status: $last_status"
+            exit 1
         else
-          echo "::set-output name=should_send_message::no"
+            echo "status of the previous build: $last_status"
+        fi
+        needs_context="${{ inputs.needs_context }}"
+        if [[ $(echo $needs_context | grep "result: failure") ]]; then
+            current_status=failure
+        else
+            current_status=success
+        fi
+        if [[ "${{ inputs.notify_on_changed_status }}" ]]; then
+            if [[ $current_status == $last_status ]]; then
+              echo "::set-output name=should_send_message::no"
+            else
+              echo "::set-output name=should_send_message::yes"
+            fi
+        else
+          if [[ $current_status == failure ]]; then
+            echo "::set-output name=should_send_message::yes"
+          elif [[ $last_status == failure ]]; then
+            echo "::set-output name=should_send_message::yes"
+          else
+            echo "::set-output name=should_send_message::no"
+          fi
         fi

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         last_status=$(curl --silent --header 'authorization: Bearer ${{ inputs.github_token }}' \
                       --header 'content-type: application/json' \
                       "https://api.github.com/repos/${{ github.repository }}/actions/workflows/$workflow_id/runs?per_page=1&status=completed&branch=${{ inputs.branch }}" | jq -r .workflow_runs[0].conclusion)
-        if [[  $last_status != success && $last_status != failure && $last_status != null ]]; then
+        if [[  $last_status != success && $last_status != failure && $last_status != cancelled && $last_status != null ]]; then
             echo "Invalid \$last_status: $last_status"
             exit 1
         else

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ outputs:
   should_send_message:
     description: "`yes|no` depending on if the message should be sent"
     value: ${{ steps.determine-notification.outputs.should_send_message }}
+  last_status:
+    description: "status of the last completed workflow"
+    value: ${{ steps.determine-notification.outputs.last_status }}
 runs:
   using: "composite"
   steps:
@@ -41,6 +44,7 @@ runs:
             exit 1
         else
             echo "status of the previous build: $last_status"
+            echo "::set-output name=last_status::$last_status"
         fi
         needs_context="${{ inputs.needs_context }}"
         if [[ $(echo $needs_context | grep "result: failure") ]]; then


### PR DESCRIPTION
If the optional input `notify_on_changed_status` is set to a non-empty string, then:
1. If the status of the current and the last build differ, then it will recommend sending the message

For tests of the new option see:
https://github.com/ssiccha/gap/actions?query=branch%3Ass%2Fminimal-slack-test